### PR TITLE
Update composer-platform-specific.json

### DIFF
--- a/src/composer-platform-specific.json
+++ b/src/composer-platform-specific.json
@@ -29,7 +29,7 @@
             "package":{
                 "name":"yandex/mystem-linux32",
                 "version":"dev-master",
-                "bin": ["mystem-3.0-linux3.5-32bit"],
+                "bin": ["mystem"],
                 "dist":{"url":"http://download.yandex.ru/mystem/mystem-3.0-linux3.5-32bit.tar.gz", "type":"tar" }
             }
         },


### PR DESCRIPTION
На 32-битную систему не ставится без этого фикса

    - Installing aotd/mystem (dev-master 7cbd8b1)
        Cloning 7cbd8b162eb8b697f243edef6c015db0da314f3b

    Writing lock file
    Generating autoload files
    Installing platform-specific dependencies
        - Installing aotd/mystem-binaries-3 (dev-master)
        Loading from cache

        Skipped installation of bin mystem-3.0-linux3.5-32bit for package aotd/mystem-binaries-3: file not         found in package
        Script MystemBinaryInstaller::update handling the post-update-cmd event terminated with an exception



        [Exception]
        Can't chmod binary file '/www/project.lan/code/code_is_here/vendor/bin/mystem'

